### PR TITLE
Fixed 5.1 and added new generators (get/set) and option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 vendor
+.phpintel 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Options:
  - --fillable=""            Rules for $fillable array columns (default: "")
  - --guarded=""             Rules for $guarded array columns (default: "ends:_id|ids,equals:id")
  - --timestamps=""          Rules for $timestamps columns (default: "ends:_at")
+ - --ignore=""|-i=""        A table names to ignore
+ - --ignoresystem|-s        List of system tables (auth, migrations, entrust package)
 
 # Running the generator
 ```php artisan make:models```

--- a/src/Commands/MakeModelsCommand.php
+++ b/src/Commands/MakeModelsCommand.php
@@ -82,11 +82,13 @@ class MakeModelsCommand extends GeneratorCommand
      */
     public function fire()
     {
-        // load the get/set function stubs
-        $folder = __DIR__ . '/../stubs/';
+        if ($this->option("getset")) {
+            // load the get/set function stubs
+            $folder = __DIR__ . '/../stubs/';
         
-        $this->setFunctionStub = $this->files->get($folder."setFunction.stub");
-        $this->getFunctionStub = $this->files->get($folder."getFunction.stub");
+            $this->setFunctionStub = $this->files->get($folder."setFunction.stub");
+            $this->getFunctionStub = $this->files->get($folder."getFunction.stub");
+        }
 
         // create rule processor
 
@@ -173,7 +175,11 @@ class MakeModelsCommand extends GeneratorCommand
         $class = str_replace('{{guarded}}', 'protected $guarded = ' . VariableConversion::convertArrayToString($properties['guarded']) . ';', $class);
         $class = str_replace('{{timestamps}}', 'public $timestamps = ' . VariableConversion::convertBooleanToString($properties['timestamps']) . ';', $class);
 
-        return $this->replaceTokensWithSetGetFunctions($properties, $class);
+        if ($this->option("getset")) {
+            $class = $this->replaceTokensWithSetGetFunctions($properties, $class);
+        }
+
+        return $class;
     }
 
     /**
@@ -288,7 +294,8 @@ class MakeModelsCommand extends GeneratorCommand
             ['timestamps', null, InputOption::VALUE_OPTIONAL, 'Rules for $timestamps columns', $this->timestampRules],
             ['ignore', "i", InputOption::VALUE_OPTIONAL, 'Ignores the tables you define, separated with ,', null],
             ['ignoresystem', "s", InputOption::VALUE_NONE, 'If you want to ignore system tables.
-            Just type --ignoresystem or -s', null]
+            Just type --ignoresystem or -s', null],
+            ['getset', 'm', InputOption::VALUE_NONE, 'Defines if you want to generate set and get methods', false]
         ];
     }
 }

--- a/src/Commands/MakeModelsCommand.php
+++ b/src/Commands/MakeModelsCommand.php
@@ -295,7 +295,7 @@ class MakeModelsCommand extends GeneratorCommand
             ['ignore', "i", InputOption::VALUE_OPTIONAL, 'Ignores the tables you define, separated with ,', null],
             ['ignoresystem', "s", InputOption::VALUE_NONE, 'If you want to ignore system tables.
             Just type --ignoresystem or -s', null],
-            ['getset', 'm', InputOption::VALUE_NONE, 'Defines if you want to generate set and get methods', false]
+            ['getset', 'm', InputOption::VALUE_NONE, 'Defines if you want to generate set and get methods']
         ];
     }
 }

--- a/src/Commands/MakeModelsCommand.php
+++ b/src/Commands/MakeModelsCommand.php
@@ -294,7 +294,7 @@ class MakeModelsCommand extends GeneratorCommand
             ['timestamps', null, InputOption::VALUE_OPTIONAL, 'Rules for $timestamps columns', $this->timestampRules],
             ['ignore', "i", InputOption::VALUE_OPTIONAL, 'Ignores the tables you define, separated with ,', null],
             ['ignoresystem', "s", InputOption::VALUE_NONE, 'If you want to ignore system tables.
-            Just type --ignoresystem or -s', null],
+            Just type --ignoresystem or -s'],
             ['getset', 'm', InputOption::VALUE_NONE, 'Defines if you want to generate set and get methods']
         ];
     }

--- a/src/Utilities/SetGetGenerator.php
+++ b/src/Utilities/SetGetGenerator.php
@@ -1,0 +1,142 @@
+<?php
+namespace Iber\Generator\Utilities;
+
+use \Illuminate\Filesystem\Filesystem;
+
+class SetGetGenerator  {
+	
+	/**
+	 * Lists of attributes to convert
+	 * @var array
+	 */
+	protected $attributes = array();
+
+	/**
+	 * Returns a template stub for set function
+	 * @var string
+	 */
+	protected $setStub = "";
+
+	/**
+	 * Returns a template stub for get function
+	 * @var string
+	 */
+	protected $getStub = "";
+
+	/**
+	 * [__construct description]
+	 * @param array  $attributes with attributes names
+	 * @param string $getStub    set stub template
+	 * @param string $setStub    get stub template
+	 */
+	public function __construct(array $attributes, $getStub, $setStub) 
+	{
+		$folder = __DIR__ . '/../stubs/';
+
+		$this->attributes = $attributes;
+		$this->getStub = $getStub;
+		$this->setStub = $setStub;
+		
+	}
+
+	/**
+	 * Returns the get functions in string
+	 * @return string
+	 */
+	public function generateGetFunctions() {
+		return $this->generateWithFunction("createGetFunctionFromAttributeName");
+	}
+
+	/**
+	 * Returns the set functions in string
+	 * @return string
+	 */
+	public function generateSetFunctions() {
+		return $this->generateWithFunction("createSetFunctionFromAttributeName");
+	}
+
+	/**
+	 * Loops the attributes and build the string with given function name
+	 * @param  string $function 
+	 * @return  string
+	 */
+	protected function generateWithFunction($function) {
+		$string = "";
+
+		foreach ($this->attributes as  $attributeName) {
+			$string .= $this->$function($attributeName);
+		}
+
+		return $string;
+	}
+
+	/**
+	 * Bulds the get function for the attribute name
+	 * @param  string $attributeName  
+	 * @return string                 
+	 */
+	public function createGetFunctionFromAttributeName($attributeName) {
+		return $this->createFunctionFromAttributeName("get", $attributeName, $this->getStub);
+	}
+
+	/**
+	 * Bulds the set function for the attribute name
+	 * @param  string $attributeName  
+	 * @return string                 
+	 */
+	public function createSetFunctionFromAttributeName($attributeName) {
+		return $this->createFunctionFromAttributeName("set", $attributeName, $this->setStub);
+	}
+
+	/**
+	 * Builds the funciton and creates the function from the stub template
+	 * @param  string $prefixFunction 
+	 * @param  string $attributeName  
+	 * @param  string $stubTemplate   
+	 * @return string                 
+	 */
+	protected function createFunctionFromAttributeName($prefixFunction, $attributeName, $stubTemplate) {
+		$function = $this->attributeNameToFunction($prefixFunction, $attributeName);
+
+		// change to stub?
+		
+		return $this->createAttributeFunction($stubTemplate, $function, $attributeName);
+	}
+
+	/**
+	 * Replaces the stub template with the data
+	 * @param  string $stubTemplate 
+	 * @param  string $function      
+	 * @param  string $attributeName 
+	 * @return string                
+	 */
+	protected function createAttributeFunction($stubTemplate, $function, $attributeName) {
+		return str_replace([
+				"{{ attribute }}",
+				"{{ function }}"
+			], [
+				$attributeName,
+				$function
+			],  $stubTemplate); 
+	}
+
+	/**
+	 * Converts the given string to function. Support database names (underscores)
+	 * @param  string $prefixFunction desired function prefix (get/set)
+	 * @param  string $str            attribute name
+	 * @param  array  $noStrip        
+	 * @return string
+	 */
+	public function attributeNameToFunction($prefixFunction, $str, array $noStrip = array())
+    {
+        // non-alpha and non-numeric characters become spaces
+        $str = preg_replace('/[^a-z0-9' . implode("", $noStrip) . ']+/i', ' ', $str);
+        $str = trim($str);
+        // uppercase the first character of each word
+        $str = ucwords($str);
+        $str = str_replace(" ", "", $str);
+        $str = ucfirst($str);
+
+        return $prefixFunction.$str;
+    }
+}

--- a/src/stubs/getFunction.stub
+++ b/src/stubs/getFunction.stub
@@ -1,0 +1,7 @@
+
+	/**
+	 * @return mixed
+	 */
+	public function {{ function }}() {
+		return $this->{{ attribute }};
+	}

--- a/src/stubs/model.stub
+++ b/src/stubs/model.stub
@@ -9,4 +9,8 @@ class {{class}} extends {{extends}} {
     {{fillable}}
 
     {{guarded}}
+
+    {{getters}}
+
+    {{setters}}
 }

--- a/src/stubs/model.stub
+++ b/src/stubs/model.stub
@@ -1,8 +1,8 @@
-<?php namespace {{namespace}};
+<?php namespace DummyNamespace;
 
 use Illuminate\Database\Eloquent\Model;
 
-class {{class}} extends {{extends}} {
+class DummyClass extends {{extends}} {
 
     {{timestamps}}
 

--- a/src/stubs/setFunction.stub
+++ b/src/stubs/setFunction.stub
@@ -1,0 +1,9 @@
+
+	/**
+	 * @param $value
+	 * @return $this
+	 */
+	public function {{ function }}($value) {
+		$this->attributes["{{ attribute }}"] = $value;
+		return $this;
+	}

--- a/src/stubs/setFunction.stub
+++ b/src/stubs/setFunction.stub
@@ -4,6 +4,6 @@
 	 * @return $this
 	 */
 	public function {{ function }}($value) {
-		$this->attributes["{{ attribute }}"] = $value;
+		$this->{{ attribute }} = $value;
 		return $this;
 	}

--- a/tests/SetGetGeneratorTest.php
+++ b/tests/SetGetGeneratorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use \Illuminate\Filesystem\Filesystem;
+
+class SetGetGeneratorTest extends PHPUnit_Framework_TestCase
+{
+	protected $generator;
+
+	protected $setFunctionStub;
+    protected $getFunctionStub;
+
+	public function __construct() {
+		// load only once
+		$this->getFunctionStub = file_get_contents("src/stubs/getFunction.stub");
+		$this->setFunctionStub = file_get_contents("src/stubs/setFunction.stub");
+	}
+
+	public function setUp() {
+		$this->generator = new Iber\Generator\Utilities\SetGetGenerator([
+        	"attribute_name",
+        	"test"
+    	], $this->getFunctionStub, $this->setFunctionStub);
+	}
+
+
+    public function testCamelCaseFunction()
+    {
+        $this->assertEquals("getTest",$this->generator->attributeNameToFunction("get", "test"));
+
+        $this->assertEquals("getTestName",$this->generator->attributeNameToFunction("get", "test_name"));
+
+        $this->assertEquals("getTestname",$this->generator->attributeNameToFunction("get", "testname"));
+
+        $this->assertEquals("getTestName",$this->generator->attributeNameToFunction("get", "test name"));
+    }
+
+
+    public function testCreateGetFunctionFromAttributeName() {
+    	$function = $this->generator->createGetFunctionFromAttributeName("test");
+    	$this->assertContains("getTest", $function);
+    	$this->assertContains('$this->test', $function);
+    }
+
+    public function testCreateSetFunctionFromAttributeName() {
+    	$function = $this->generator->createSetFunctionFromAttributeName("test");
+    	$this->assertContains("setTest", $function);
+    	$this->assertContains('$this->attributes', $function);
+    	$this->assertContains('"test"', $function);
+    }
+
+    public function testGenerateGet() {
+    	$text = $this->generator->generateGetFunctions();
+    	$this->assertNotEquals("", $text);
+    	$this->assertNotContains("setTest", $text);
+    	$this->assertContains("getTest", $text);
+    	$this->assertContains("getAttributeName", $text);
+    }
+
+    public function testGenerateSet() {
+    	$text = $this->generator->generateSetFunctions();
+    	$this->assertNotEquals("", $text);
+    	$this->assertNotContains("getTest", $text);
+    	$this->assertContains("setTest", $text);
+    	$this->assertContains("setAttributeName", $text);
+    }
+}


### PR DESCRIPTION
Hi,

on laravel 5.1 the class and namespace was not replaced. I've replaced old name it with new names.

I've also added set and get generator (optional via -m or --getset), ignore option for ignoring specific tables and system tables (auth, migration and entrust package tables). Probably the system ignore should be in config.

Tested on laravel 5.1. The get and set output:

```
/**
 * @return mixed
 */
public function getName() {
    return $this->name;
}

/**
 * @param $value
 * @return $this
 */
public function setName($value) {
    $this->attributes["name"] = $value;
    return $this;
}

 /**
 * @param $value
 * @return $this
 */
public function setExternalId($value) {
    $this->attributes["external_id"] = $value;
    return $this;
}
```

First are getters then setters. The generation has tests.

Martin.
