### PR TITLE
Fixed stub file and getter/setter generation

### DIFF
--- a/src/Commands/MakeModelsCommand.php
+++ b/src/Commands/MakeModelsCommand.php
@@ -177,6 +177,8 @@ class MakeModelsCommand extends GeneratorCommand
 
         if ($this->option("getset")) {
             $class = $this->replaceTokensWithSetGetFunctions($properties, $class);
+        } else {
+            $class = str_replace(['{{setters}}', '{{getters}}'], '', $class);
         }
 
         return $class;
@@ -205,8 +207,8 @@ class MakeModelsCommand extends GeneratorCommand
             '{{setters}}',
             '{{getters}}'
             ], [
-            $setters,
-            $getters
+                $setters,
+                $getters
             ], $class);
     }
 

--- a/src/stubs/model.stub
+++ b/src/stubs/model.stub
@@ -1,8 +1,8 @@
-<?php namespace DummyNamespace;
+<?php namespace {{namespace}};
 
 use Illuminate\Database\Eloquent\Model;
 
-class DummyClass extends {{extends}} {
+class {{class}} extends {{extends}} {
 
     {{timestamps}}
 


### PR DESCRIPTION
There was an issue with #3 where the stubs had dummy content in them and if the option "getset" wasn't used during the generation, the placeholders in the stub files were left untouched rather than removed.

This is now fixed.
