### PR TITLE
Fix for 5.1

### DIFF
--- a/src/stubs/model.stub
+++ b/src/stubs/model.stub
@@ -1,8 +1,8 @@
-<?php namespace {{namespace}};
+<?php namespace DummyNamespace;
 
 use Illuminate\Database\Eloquent\Model;
 
-class {{class}} extends {{extends}} {
+class DummyClass extends {{extends}} {
 
     {{timestamps}}
 


### PR DESCRIPTION
Hello.
Quick in-Github fix here.
5.1 of Illuminate Console seems to have gone back to DummyBla notation https://github.com/illuminate/console/compare/5.0...5.1

It might be useful to tag the project with 5.0 and 5.1 and require specific versions in the composer.json file too? This will be extra work for you so I didn't want to include the composer changes in this.

Hope this helps.
