### PR TITLE
Support PHP5 by separating cast to its own line.

### DIFF
--- a/src/Commands/MakeModelsCommand.php
+++ b/src/Commands/MakeModelsCommand.php
@@ -118,7 +118,8 @@ class MakeModelsCommand extends GeneratorCommand
         $tables = $this->getSchemaTables();
 
         foreach ($tables as $table) {
-            $this->generateTable( ((object) $table)->name );
+            $table = (object) $table;
+            $this->generateTable($table->name);
         }
     }
 
@@ -383,7 +384,8 @@ class MakeModelsCommand extends GeneratorCommand
         }
 
         if (count($primaryKeyResult) == 1) {
-            return ((object) $primaryKeyResult[0])->COLUMN_NAME;
+            $column = (object) $primaryKeyResult[0];
+            return $column->COLUMN_NAME;
         }
 
         return null;


### PR DESCRIPTION
To be complete, this should check if it is an array and cast as there are additional side effects that should be checked for, in case at any point the query fails and null or another value is returned.

As the original PR was a quick hack to get the command working on PHP7, this is also a quick hack to get it working again on PHP5.