### PR TITLE
properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Options:
                                               Just type --ignoresystem or -s
   -m, --getset                   Defines if you want to generate set and get methods
   -h, --help                     Display this help message
+  -d, --connection               Database connection name
   -q, --quiet                    Do not output any message
   -c, --variables                Set columns as variables set [TRUE] to set as variables and [FALSE] for comments.
   -V, --version                  Display this application version

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Options:
   -m, --getset                   Defines if you want to generate set and get methods
   -h, --help                     Display this help message
   -q, --quiet                    Do not output any message
+  -c, --variables                Set columns as variables set [TRUE] to set as variables and [FALSE] for comments.
   -V, --version                  Display this application version
       --ansi                     Force ANSI output
       --no-ansi                  Disable ANSI output

--- a/src/Commands/MakeModelsCommand.php
+++ b/src/Commands/MakeModelsCommand.php
@@ -255,6 +255,11 @@ class MakeModelsCommand extends GeneratorCommand
         $class = str_replace('{{guarded}}', 'protected $guarded = ' . VariableConversion::convertArrayToString($properties['guarded']) . ';', $class);
         $class = str_replace('{{timestamps}}', 'public $timestamps = ' . VariableConversion::convertBooleanToString($properties['timestamps']) . ';', $class);
         
+        if ($c = $this->option('connection')) {
+            $class = str_replace('{{connection}}', 'protected $connection = \''.$c."';\n", $class);
+        } else {
+            $class = str_replace("{{connection}}\n\n", '', $class);
+        }
         if ($this->option("getset")) {
             $class = $this->replaceTokensWithSetGetFunctions($properties, $class);
         } else {
@@ -322,7 +327,7 @@ class MakeModelsCommand extends GeneratorCommand
         if ('true' == $asVariables) $col_comments .= $fillableVariables->generateComProperties();
         elseif ('false' == $asVariables) $col_variables .= $fillableVariables->generateVarProperties();
         
-        return str_replace(["{{colcommented}}\n", "{{colvariable}}\n",], [$col_comments . "\n", $col_variables. "\n",], $class);
+        return str_replace(["{{colcommented}}\n", "{{colvariable}}\n",], [$col_comments . "\n", $col_variables . "\n",], $class);
     }
     
     /**
@@ -485,6 +490,7 @@ class MakeModelsCommand extends GeneratorCommand
             ['timestamps', NULL, InputOption::VALUE_OPTIONAL, 'Rules for $timestamps columns', $this->timestampRules],
             ['ignore', "i", InputOption::VALUE_OPTIONAL, 'Ignores the tables you define, separated with ,', NULL],
             ['force', "f", InputOption::VALUE_OPTIONAL, 'Force override', FALSE],
+            ['connection', "d", InputOption::VALUE_OPTIONAL, 'Database connection', FALSE],
             ['ignoresystem', "s", InputOption::VALUE_NONE, 'If you want to ignore system tables.
             Just type --ignoresystem or -s'],
             ['getset', 'm', InputOption::VALUE_NONE, 'Defines if you want to generate set and get methods'],

--- a/src/Utilities/VariableGenerator.php
+++ b/src/Utilities/VariableGenerator.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Iber\Generator\Utilities;
+
+/**
+ * Class VariableGenerator
+ * @package Iber\Generator\Utilities
+ */
+class VariableGenerator
+{
+    
+    /**
+     * Lists of attributes to convert
+     * @var array
+     */
+    protected $attributes = [];
+    
+    /**
+     * Returns a template stub for set function
+     * @var string
+     */
+    protected $commentStub = "";
+    
+    /**
+     * Returns a template stub for get function
+     * @var string
+     */
+    protected $variableStub = "";
+    
+    /**
+     * [__construct description]
+     *
+     * @param array  $attributes with attributes names
+     * @param string $varStub    set stub template
+     * @param string $comStub    get stub template
+     */
+    public function __construct(array $attributes, $varStub, $comStub)
+    {
+        $this->attributes   = $attributes;
+        $this->variableStub = $varStub;
+        $this->commentStub  = $comStub;
+        
+    }
+    
+    /**
+     * Returns the get functions in string
+     * @return string
+     */
+    public function generateVarProperties()
+    {
+        return $this->generateWithFunction("createVarPropertyFromAttributeName");
+    }
+    
+    /**
+     * Returns the set functions in string
+     * @return string
+     */
+    public function generateComProperties()
+    {
+        return $this->generateWithFunction("createComPropertyFromAttributeName");
+    }
+    
+    /**
+     * Loops the attributes and build the string with given property name
+     *
+     * @param  string $function
+     *
+     * @return  string
+     */
+    protected function generateWithFunction($function)
+    {
+        $string = "";
+        
+        foreach ($this->attributes as $attribute) {
+            $string .= $this->$function($attribute->name, $attribute->data_type);
+        }
+        
+        return $string;
+    }
+    
+    /**
+     * Bulds the get function for the attribute name
+     *
+     * @param  string  $attributeName
+     *
+     * @param   string $dataType
+     *
+     * @return string
+     */
+    public function createVarPropertyFromAttributeName($attributeName, $dataType)
+    {
+        return $this->createPropertyFromAttributeName($attributeName, $dataType, $this->variableStub);
+    }
+    
+    /**
+     * Bulds the set function for the attribute name
+     *
+     * @param  string  $attributeName
+     *
+     * @param   string $dataType
+     *
+     * @return string
+     */
+    public function createComPropertyFromAttributeName($attributeName, $dataType)
+    {
+        return $this->createPropertyFromAttributeName($attributeName, $dataType, $this->commentStub);
+    }
+    
+    /**
+     * Builds the property and creates the property from the stub template
+     *
+     * @param  string $attributeName
+     * @param  string $dataType
+     * @param  string $stubTemplate
+     *
+     * @return string
+     * @internal param string $prefixFunction
+     */
+    protected function createPropertyFromAttributeName($attributeName, $dataType, $stubTemplate)
+    {
+        return $this->createAttributeProperty($stubTemplate, $attributeName, $dataType);
+    }
+    
+    /**
+     * Replaces the stub template with the data
+     *
+     * @param  string $stubTemplate
+     * @param  string $attributeName
+     *
+     * @param  string $dataType
+     *
+     * @return string
+     * @internal param string $function
+     */
+    protected function createAttributeProperty($stubTemplate, $attributeName, $dataType)
+    {
+        /*
+         * We can handle only unquoted field names
+         */
+        $attributeName = preg_replace('/[^0-9a-zA-Z\$_]+/i', '', $attributeName);
+        return str_replace(["{{colname}}", "{{returndt}}", "{{datatype}}",], ['$' . $attributeName, $this->dataType($dataType) . '|', $dataType,], $stubTemplate);
+    }
+    
+    /**
+     * To assist in matching various data types to php data types
+     *
+     * @param $data_type
+     *
+     * @return int|string
+     */
+    protected function dataType($data_type)
+    {
+        $mapping = ['string'  => ['varchar', 'varbinary', 'binary', 'set', 'enum', 'longtext', 'longblob', 'mediumtext', 'text', 'datetime', 'timestamp', 'time', 'char', 'tinyblob', 'tinytext',
+                                  'blob', 'mediumblob']
+                    , 'date'  => []
+                    , 'int'   => ['tinyint', 'smallint', 'mediumint', 'bigint', 'year']
+                    , 'float' => ['double', 'decimal']
+                    , 'bool'  => ['boolean'],
+        ];
+        foreach ($mapping as $dt => $alias) {
+            if (in_array($data_type, $alias) || $dt == $data_type) return $dt;
+        }
+        return 'string';
+    }
+}

--- a/src/stubs/colComment.stub
+++ b/src/stubs/colComment.stub
@@ -1,0 +1,2 @@
+
+ * @property {{returndt}}mixed {{colname}}

--- a/src/stubs/colVariable.stub
+++ b/src/stubs/colVariable.stub
@@ -1,0 +1,6 @@
+
+    /**
+     * Data Type: {{datatype}}
+     * @var {{returndt}}mixed
+     */
+    public {{colname}};

--- a/src/stubs/model.stub
+++ b/src/stubs/model.stub
@@ -12,6 +12,8 @@ class DummyClass extends {{shortNameExtends}}
 {
     {{colvariable}}
 
+    {{connection}}
+
     {{table}}
 
     {{primaryKey}}{{timestamps}}

--- a/src/stubs/model.stub
+++ b/src/stubs/model.stub
@@ -6,9 +6,12 @@ use {{extends}};
 
 /**
  * Class DummyClass
+ {{colcommented}}
  */
 class DummyClass extends {{shortNameExtends}}
 {
+    {{colvariable}}
+
     {{table}}
 
     {{primaryKey}}{{timestamps}}


### PR DESCRIPTION
Added columns as properties for model. Properties can be set via comments or directly in the model.
artisan variable `-c true` sets the properties as comments while `-c false` sets them in model as variables.
Assist in IDEs such as Phpstorm for intellisense.
```
* @property string $column1
* @property int $column2...
```
Or
```
/** @var ... */
public $column1;
/** @var ... */
public $column2...
```