### PR TITLE
Update MakeModelsCommand.php

### DIFF
--- a/src/Commands/MakeModelsCommand.php
+++ b/src/Commands/MakeModelsCommand.php
@@ -103,7 +103,8 @@ class MakeModelsCommand extends GeneratorCommand
         // create rule processor
 
         $this->ruleProcessor = new RuleProcessor();
-        $this->databaseEngine = config('database.default', 'mysql');
+        //Get the database engine driver name
+        $this->databaseEngine = config('database.connections')[$this->databaseEngine]['driver'];
 
         \Event::listen(StatementPrepared::class, function ($event) {
             /** @var \PDOStatement $statement */


### PR DESCRIPTION
Fixed case (issue  #44 ) where DB connection name is not the default name for that driver. This caused errors
Code does not assume the name of the connection is the same as the driver